### PR TITLE
Enable editing student's personal info

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -17,7 +17,7 @@ class StudentsController < ApplicationController
 
   def update
     params.permit!
-    @student.update(params[:student])
+    @student.update!(student_params)
     redirect_to student_path(@student)
   end
 
@@ -40,6 +40,22 @@ class StudentsController < ApplicationController
 
   def authorize_user
     authorize User
+  end
+
+  def student_params
+    params.require(:student).permit(
+      :cvu,
+      :name,
+      :paternal_last_name,
+      :maternal_last_name,
+      :rfc,
+      :curp,
+      :gender,
+      :marital_status,
+      :birth_date,
+      :country_birth,
+      :state_birth,
+    )
   end
 
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,18 +1,26 @@
 require 'roo'
 class StudentsController < ApplicationController
+  before_action :set_student, only: [:show, :edit, :update]
 
   def index
+    authorize User
     @users = User.student
   end
 
   def show
-    @student = Student.find(params[:id])
     @user = @student.user
     authorize @student
   end
 
-  def new
-    @user = User.new
+  def edit
+    authorize User
+  end
+
+  def update
+    authorize User
+    params.permit!
+    @student.update(params[:student])
+    redirect_to student_path(@student)
   end
 
   def destroy
@@ -26,6 +34,10 @@ class StudentsController < ApplicationController
     (0..headers.length).each do |i|
     end
     headers
+  end
+
+  def set_student
+    @student = Student.find(params[:id])
   end
 
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,9 +1,9 @@
 require 'roo'
 class StudentsController < ApplicationController
   before_action :set_student, only: [:show, :edit, :update]
+  before_action :authorize_user, only: [:index, :edit, :update, :destroy]
 
   def index
-    authorize User
     @users = User.student
   end
 
@@ -13,11 +13,9 @@ class StudentsController < ApplicationController
   end
 
   def edit
-    authorize User
   end
 
   def update
-    authorize User
     params.permit!
     @student.update(params[:student])
     redirect_to student_path(@student)
@@ -38,6 +36,10 @@ class StudentsController < ApplicationController
 
   def set_student
     @student = Student.find(params[:id])
+  end
+
+  def authorize_user
+    authorize User
   end
 
 end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -16,7 +16,6 @@ class StudentsController < ApplicationController
   end
 
   def update
-    params.permit!
     @student.update!(student_params)
     redirect_to student_path(@student)
   end

--- a/app/views/devise/registrations/new_with_student.html.erb
+++ b/app/views/devise/registrations/new_with_student.html.erb
@@ -26,56 +26,11 @@
           </div>
 
           <%= f.fields_for :student_attributes do |s| %>
-            <div class="row">
-              <div class="col s4 input-field inline">
-                <%= s.label :Nombre,:style=>'color:red;'%>
-                <%= s.text_field :name, :required => true%>
-              </div>
-              <div class="col s4 input-field inline">
-                <%= s.label :Primer_Apellido %>
-                <%= s.text_field :paternal_last_name %>
-              </div>
-              <div class="col s4 input-field inline">
-                <%= s.label :Segundo_Apellido %>
-                <%= s.text_field :maternal_last_name %>
-              </div>
-            </div>
+            <%= render "students/form", f: s%>
             <div class="row">
               <div class="col s2 input-field inline">
                 <%= f.label :Desc_estatus_solicitud %>
                 <%= f.date_field :desc_request_status, :value => Time.now.strftime("%Y-%m-%d")  %>
-              </div>
-              <div class="col s2 input-field inline">
-                <%= s.label :CVU,:style=>'color:red;'%>
-                <%= s.number_field :cvu, :required => true %>
-              </div>
-              <div class="col s2 input-field inline">
-                <%= s.label :RFC,:style=>'color:red;'%>
-                <%= s.text_field :rfc, :required => true%>
-              </div>
-              <div class="col s2 input-field inline">
-                <%= s.label :CURP,:style=>'color:red;'%>
-                <%= s.text_field :curp, :required => true %>
-              </div>
-              <div class="col s3 input-field inline">
-                <%= s.label :Fecha_de_nacimiento %>
-                <%= s.date_field :birth_date, :value => Time.now.strftime("%Y-%m-%d")  %>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col s2 input-field inline">
-                <%= s.select :gender, options_for_select([["Hombre", "Hombre"], ["Mujer", "Mujer"]]), {:include_blank => "Género:"}, { class: 'browser-default'} %>
-              </div>
-              <div class="col s2 input-field inline">
-                <%= s.select :marital_stauts, options_for_select([["Soltero", "Soltero"], ["Casado", "Casado"]]), {:include_blank => "Estado Civil:"}, { class: 'browser-default'} %>
-              </div>
-              <div class="col s2 input-field inline">
-                <%= s.label :País_de_Nacimiento,:style=>'color:red;'%>
-                <%= s.text_field :country_birth, :required => true %>
-              </div>
-              <div class="col s2 input-field inline">
-                <%= s.label :Estado_de_Nacimiento,:style=>'color:red;'%>
-                <%= s.text_field :state_birth, :required => true %>
               </div>
               <%= s.fields_for :contact_information_attributes do |c| %>
                 <div class="col s2 input-field inline">

--- a/app/views/devise/registrations/new_with_student.html.erb
+++ b/app/views/devise/registrations/new_with_student.html.erb
@@ -26,7 +26,7 @@
           </div>
 
           <%= f.fields_for :student_attributes do |s| %>
-            <%= render "students/form", f: s%>
+            <%= render "students/form", f: s %>
             <div class="row">
               <div class="col s2 input-field inline">
                 <%= f.label :Desc_estatus_solicitud %>

--- a/app/views/devise/registrations/new_with_student.html.erb
+++ b/app/views/devise/registrations/new_with_student.html.erb
@@ -84,7 +84,7 @@
                 </div>
                 <div class="col s2 input-field inline">
                   <%= c.label :Celular %>
-                  <%= c.telephone_field :cell_phone_number %>
+                  <%= c.telephone_field :cellphone_number %>
                 </div>
             </div>
             <h5>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -27,7 +27,7 @@
         <li id="dash_dashboard"><%= link_to 'Registrar administradores', new_user_registration_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
       <% end %>
     <% else%>
-      <li id="dash_dashboard"><a class="waves-effect" href="#!"><b>Perfil</b></a></li>
+      <li id="dash_dashboard"><%= link_to 'Perfil', student_path(current_user.student), :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/students/_form.html.erb
+++ b/app/views/students/_form.html.erb
@@ -1,58 +1,48 @@
-<div class="form-content" style="padding-right:5%;padding-left:5%">
-  <h4 class="center-align">Registro de Becario</h4>
-  <%= form_for(user) do |f| %>
-    <div class="form-section">
-      <div class="row">
-        <div class="col s4 input-field inline">
-          <input id="user_name" type="text" class="validate">
-          <label for="user_name">Nombre</label>
-        </div>
-        <div class="col s4 input-field inline">
-          <input id="user_paternal_last_name" type="text" class="validate">
-          <label for="user_paternal_last_name">Primer Apellido</label>
-        </div>
-        <div class="col s4 input-field inline">
-          <input id="user_maternal_last_name" type="text" class="validate">
-          <label for="user_maternal_last_name">Segundo Apellido</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col s12 input-field inline">
-          <input id="user_email" type="email" class="validate">
-          <label for="user_email">Email</label>
-          <span class="helper-text" data-error="Introduce un email valido." data-success="Email valido"></span>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col s6 input-field inline">
-          <input id="user_password" type="password" class="validate" pattern=".{6,}" title="La contrasenña debe tener 6 o más caracteres">
-          <label for="user_password">Contraseña</label>
-          <span class="helper-text" data-error="Introduce una contraseña con más de 5 caracteres." data-success="Contraseña valida."></span>
-        </div>
-        <div class="col s6 input-field inline">
-          <input id="user_password_confirmation" type="password" class="validate" pattern=".{6,}" title="La contrasenña debe tener 6 o más caracteres">
-          <label for="user_password_confirmation">Confirmar Contraseña</label>
-          <span class="helper-text" data-error="Introduce una contraseña con más de 5 caracteres." data-success="Contraseña valida."></span>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col s3 input-field inline">
-          <input id="user_cvu" type="date" class="validate">
-          <label for="user_cvu">Request Status***</label>
-        </div>
-        <div class="col s3 input-field inline">
-          <input id="user_cvu" type="number" class="validate">
-          <label for="user_cvu">CVU</label>
-        </div>
-        <div class="col s3 input-field inline">
-          <input id="user_rfc" type="text">
-          <label for="user_rfc">RFC</label>
-        </div>
-        <div class="col s3 input-field inline">
-          <input id="user_curp" type="text" class="validate">
-          <label for="user_password">CURP</label>
-        </div>
-      </div>
-    </div>
-  <% end %>
+<div class="row">
+  <div class="col s4 input-field inline">
+    <%= f.label :Nombre,:style=>'color:red;'%>
+    <%= f.text_field :name, :required => true%>
+  </div>
+  <div class="col s4 input-field inline">
+    <%= f.label :Primer_Apellido %>
+    <%= f.text_field :paternal_last_name %>
+  </div>
+  <div class="col s4 input-field inline">
+    <%= f.label :Segundo_Apellido %>
+    <%= f.text_field :maternal_last_name %>
+  </div>
+</div>
+<div class="row">
+  <div class="col s2 input-field inline">
+    <%= f.label :CVU,:style=>'color:red;'%>
+    <%= f.number_field :cvu, :required => true %>
+  </div>
+  <div class="col s2 input-field inline">
+    <%= f.label :RFC,:style=>'color:red;'%>
+    <%= f.text_field :rfc, :required => true%>
+  </div>
+  <div class="col s2 input-field inline">
+    <%= f.label :CURP,:style=>'color:red;'%>
+    <%= f.text_field :curp, :required => true %>
+  </div>
+  <div class="col s3 input-field inline">
+    <%= f.label :Fecha_de_nacimiento %>
+    <%= f.date_field :birth_date, :value => Time.now.strftime("%Y-%m-%d")  %>
+  </div>
+</div>
+<div class="row">
+  <div class="col s2 input-field inline">
+    <%= f.select :gender, options_for_select([["Hombre", "Hombre"], ["Mujer", "Mujer"]]), {:include_blank => "Género:"}, { class: 'browser-default'} %>
+  </div>
+  <div class="col s2 input-field inline">
+    <%= f.select :marital_status, options_for_select([["Soltero", "Soltero"], ["Casado", "Casado"]]), {:include_blank => "Estado Civil:"}, { class: 'browser-default'} %>
+  </div>
+  <div class="col s2 input-field inline">
+    <%= f.label :País_de_Nacimiento,:style=>'color:red;'%>
+    <%= f.text_field :country_birth, :required => true %>
+  </div>
+  <div class="col s2 input-field inline">
+    <%= f.label :Estado_de_Nacimiento,:style=>'color:red;'%>
+    <%= f.text_field :state_birth, :required => true %>
+  </div>
 </div>

--- a/app/views/students/_student_info.html.erb
+++ b/app/views/students/_student_info.html.erb
@@ -3,6 +3,9 @@
     <div class="table-header" style="background:#26a69a">
       <span class="table-title" style="color:#ffffff;font-weight: bold;">Información Personal</span>
       <div class="actions">
+        <% if can_update_personal %>
+          <%= link_to  "Editar", students_path, :class=>"white-text" %>
+        <% end %>
       </div>
     </div>
     <table id="datatable">

--- a/app/views/students/_student_info.html.erb
+++ b/app/views/students/_student_info.html.erb
@@ -4,7 +4,7 @@
       <span class="table-title" style="color:#ffffff;font-weight: bold;">Información Personal</span>
       <div class="actions">
         <% if can_update_personal %>
-          <%= link_to  "Editar", students_path, :class=>"white-text" %>
+          <%= link_to  "Editar", edit_student_url(student), :class=>"white-text" %>
         <% end %>
       </div>
     </div>

--- a/app/views/students/edit.html.erb
+++ b/app/views/students/edit.html.erb
@@ -1,0 +1,16 @@
+<main style="padding-left: 240px">
+  <div class="row">
+    <div class="col s12" style="padding-top: 20px;"><h4 class="center-align">Actualizar información</h4> </div>
+    <div class="col s12 m4 l1"><p></p></div>
+    <div class="col s12 m4 l10">
+
+        <div id="basic-form" class="section">
+            <%= form_for @student do |f| %>
+                <%= render "form", f: f %>
+                <div class="actions center-align">
+                    <%= f.submit "Actualizar", :class=>"btn"%>
+                </div>
+            <% end %>
+        </div>
+    </div>
+</main>

--- a/app/views/students/edit.html.erb
+++ b/app/views/students/edit.html.erb
@@ -1,6 +1,6 @@
 <main style="padding-left: 240px">
   <div class="row">
-    <div class="col s12" style="padding-top: 20px;"><h4 class="center-align">Actualizar información</h4> </div>
+    <div class="col s12" style="padding-top: 20px;"><h4 class="center-align">Actualizar datos personales</h4> </div>
     <div class="col s12 m4 l1"><p></p></div>
     <div class="col s12 m4 l10">
 

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -1,1 +1,0 @@
-<%= render "form", user: @user %>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col s12"><p></p></div>
     <div class="col s12 m4 l2"><p></p></div>
-    <%= render "student_info", user: @user, student: @student %>
+    <%= render "student_info", user: @user, student: @student, can_update_personal: (current_user.admin? or current_user.super_admin?) %>
     <div class="col s12 m4 l2"><p></p></div>
   </div>
 </main>


### PR DESCRIPTION
Enable admin and super admin to edit student's personal information.
This PR also fixes a bug which didn't allow students to be registered due to a typo.

Tests: Modify a user and see the changes saved in the DB
![Screenshot from 2020-04-02 15-49-43](https://user-images.githubusercontent.com/15165722/78303339-b45e9e80-74f9-11ea-8a77-12bb2b9ac500.png)
![Screenshot from 2020-04-02 15-49-48](https://user-images.githubusercontent.com/15165722/78303346-b7f22580-74f9-11ea-89fb-4aa05ee3ca70.png)
