### PR TITLE
BUG005: Fix students table crash

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,6 +1,6 @@
 require 'roo'
 class StudentsController < ApplicationController
-  before_action :set_student, only: [:show, :edit, :update, :history]
+  before_action :set_student, only: [:show, :edit, :update, :destroy, :history]
   before_action :authorize_user, only: [:index, :edit, :update, :destroy]
 
   def index
@@ -21,9 +21,9 @@ class StudentsController < ApplicationController
   end
 
   def destroy
-    @user = User.find(params[:id])
+    @user = @student.user
     @user.destroy
-    redirect_to users_path
+    redirect_to students_path
   end
 
   def history

--- a/app/views/students/_students_table.html.erb
+++ b/app/views/students/_students_table.html.erb
@@ -12,7 +12,7 @@
             <th>Nombre</th>
             <th>Universidad</th>
             <th>Disciplina</th>
-            <th>Area</th>
+            <th>Area de Estudio</th>
             <th>  </th>
         </tr>
         </thead>
@@ -21,9 +21,9 @@
             <tr>
             <td><%= user.student.cvu %></td>
             <td><%= user.student.name %> <%= user.student.paternal_last_name %> <%= user.student.maternal_last_name %></td>
-            <td><%= user.school %></td>
-            <td><%= user.discipline %></td>
-            <td><%= user.expertise_area %></td>
+            <td><%= user.student.scholarships.any? ? user.student.scholarships.last.school : 'N/A' %></td>
+            <td><%= user.student.scholarships.any? ? user.student.scholarships.last.discipline : 'N/A' %></td>
+            <td><%= user.student.scholarships.any? ? user.student.scholarships.last.study_area : 'N/A' %></td>
             <td><%= link_to 'Show', student_path(user.id), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
                 <%= link_to "Eliminar", user.student, method: :delete, data: { confirm: '¿Estás seguro que quieres eliminar al usuario?' },:style=>'color:white;;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn" %></td>
             </tr>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   db:
     image: postgres:9.6
     ports:
-      - 5433:5432
+      - 5432:5432
     volumes:
       - .:/code
       - postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
Table was using old db models.
Fixed:
- Students table crash
- Student deletion
- Docker config typo causing db port not to be exposed, which prevents db tools from being able to examine the db