### PR TITLE
Enable mass upload of former students

### DIFF
--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -1,5 +1,6 @@
-require 'roo'
 class ScholarshipsController < ApplicationController
+  include ApplicationHelper
+
   def index
   end
 
@@ -12,82 +13,10 @@ class ScholarshipsController < ApplicationController
   end
 
   def import_scholarships
-    file = params[:file]
-    file_type = file_type = file.present? ? file.original_filename.split('.').last.to_s.downcase : ''
-    if file.present? and (file_type == 'csv' or file_type == 'xlsx' or file_type == 'xls')
-      update_imported_user(file)
-    else
-      redirect_to users_path, flash: {danger: 'csv'}
-    end
+    import_users(params[:file], 'student', students_path, scholarship_oportunities_path(params[:scholarship_oportunity_id].to_i))
   end
 
   private
-
-  def update_imported_user(file)
-    spreadsheet = open_spreadsheet(file)
-    header = spreadsheet.row(1)
-    (2..spreadsheet.last_row).each do |i|
-      row = Hash[[header, spreadsheet.row(i)].transpose]
-      puts(header)
-      user = User.new(
-        email: row['CORREO'],
-        :password => '111111',
-        :password_confirmation => '111111'
-      )
-
-      user.build_student(
-        cvu: row['CVU'],
-        name: row['NOMBRE'],
-        paternal_last_name: row['APELLIDO PATERNO'],
-        maternal_last_name: row['APELLIDO MATERNO'],
-        rfc: row['RFC'],
-        curp: row['CURP'],
-        gender: row['GÉNERO'],
-        marital_status: row['ESTADO CIVIL'],
-        birth_date: row['FECHA NACIMIENTO'],
-        state_birth: row['ESTADO NACIMIENTO']
-      )
-
-      user.student.build_contact_information(
-        street_address: row['DOMICILIO CALLE'],
-        street_number_address_ext: row['DOMICILIO NUM. EXT.'],
-        street_number_address_int: row['DOMICILIO NUM. INT.'],
-        neighborhood: row['DOMICILIO COLONIA'],
-        city: row['DOMICILIO CIUDAD'],
-        municipality: row['DOMICILIO MUNICIPIO'],
-        state: row['DOMICILIO ESTADO'],
-        phone_number: row['TELÉFONO'],
-        cellphone_number: row['CELULAR']
-      )
-      user.student.scholarships.build(
-        scholarship_oportunity_id: params[:scholarship_oportunity_id].to_i,
-        studies_start: row['INICIO DE ESTUDIOS'],
-        studies_end: row['FIN DE ESTUDIOS'],
-        start: row['INICIO DE BECA'],
-        end: row['FIN DE BECA'],
-        institution: row['INSTITUCIÓN'],
-        entity: row['ENTIDAD'],
-        desired_support: row['APOYO A OBTENER'],
-        program: row['PROGRAMA'],
-        study_area: row['ÁREA DEL CONOCIMIENTO'],
-        study_field: row['CAMPO'],
-        discipline: row['DISCIPLINA'],
-        sub_discipline: row['SUBDISCIPLINA'],
-        most_recent_gpa: row['PROMEDIO ÚLTIMO GRADO']
-      )
-      user.save
-    end
-    redirect_to scholarship_oportunities_path(params[:scholarship_oportunity_id].to_i)
-  end
-
-  def open_spreadsheet(file)
-    case File.extname(file.original_filename)
-    when ".csv" then  Roo::CSV.new(file.path, packed: nil, file_warning: :ignore, csv_options: {encoding: Encoding::SJIS})
-    when ".xls" then  Roo::Excel.new(file.path, packed: nil, file_warning: :ignore)
-    when ".xlsx" then  Roo::Excelx.new(file.path, packed: nil, file_warning: :ignore)
-    else raise "Unknown file type: #{file.original_filename}"
-    end
-  end
 
   def scholarship_params
     params.require(:scholarship).permit(:student_id, :scholarship_oportunity_id)

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,7 +1,8 @@
-require 'roo'
 class StudentsController < ApplicationController
+  include ApplicationHelper
+
   before_action :set_student, only: [:show, :edit, :update, :destroy, :history]
-  before_action :authorize_user, only: [:index, :destroy]
+  before_action :authorize_user, only: [:index, :destroy, :former_students, :former_students_upload, :import_former_students]
   before_action :authorize_update, only: [:edit, :update]
 
   FIELD_TO_NAME = { 
@@ -28,6 +29,17 @@ class StudentsController < ApplicationController
 
   def index
     @users = User.student
+  end
+
+  def former_students
+    @users = User.former_student
+  end
+
+  def former_students_upload
+  end
+
+  def import_former_students
+    import_users(params[:file], 'former_student', former_students_upload_path, former_students_path)
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+require 'roo'
+
 module ApplicationHelper
 
   def humanized_role_name(current_user)
@@ -6,5 +8,83 @@ module ApplicationHelper
     return "Super Administrador" if current_user.super_admin?
     return "Exbecario" if current_user.former_student?
     return "Empresa" if current_user.company?
+  end
+
+  def import_users(file, role, error_redirect, success_redirect)
+    file_type = file_type = file.present? ? file.original_filename.split('.').last.to_s.downcase : ''
+    if file.present? and (file_type == 'csv' or file_type == 'xlsx' or file_type == 'xls')
+      update_imported_user(file, role, success_redirect)
+    else
+      redirect_to error_redirect, flash: {danger: 'csv'}
+    end
+  end
+
+  def update_imported_user(file, role, success_redirect)
+    spreadsheet = open_spreadsheet(file)
+    header = spreadsheet.row(1)
+    (2..spreadsheet.last_row).each do |i|
+      row = Hash[[header, spreadsheet.row(i)].transpose]
+      puts(header)
+      user = User.new(
+        email: row['CORREO'],
+        :password => row['CURP'],
+        :password_confirmation => row['CURP'],
+        :role => role
+      )
+
+      user.build_student(
+        cvu: row['CVU'],
+        name: row['NOMBRE'],
+        paternal_last_name: row['APELLIDO PATERNO'],
+        maternal_last_name: row['APELLIDO MATERNO'],
+        rfc: row['RFC'],
+        curp: row['CURP'],
+        gender: row['GÉNERO'],
+        marital_status: row['ESTADO CIVIL'],
+        birth_date: row['FECHA NACIMIENTO'],
+        state_birth: row['ESTADO NACIMIENTO']
+      )
+
+      user.student.build_contact_information(
+        street_address: row['DOMICILIO CALLE'],
+        street_number_address_ext: row['DOMICILIO NUM. EXT.'],
+        street_number_address_int: row['DOMICILIO NUM. INT.'],
+        neighborhood: row['DOMICILIO COLONIA'],
+        city: row['DOMICILIO CIUDAD'],
+        municipality: row['DOMICILIO MUNICIPIO'],
+        state: row['DOMICILIO ESTADO'],
+        phone_number: row['TELÉFONO'],
+        cellphone_number: row['CELULAR']
+      )
+      if user.student?
+        user.student.scholarships.build(
+          scholarship_oportunity_id: params[:scholarship_oportunity_id].to_i,
+          studies_start: row['INICIO DE ESTUDIOS'],
+          studies_end: row['FIN DE ESTUDIOS'],
+          start: row['INICIO DE BECA'],
+          end: row['FIN DE BECA'],
+          institution: row['INSTITUCIÓN'],
+          entity: row['ENTIDAD'],
+          desired_support: row['APOYO A OBTENER'],
+          program: row['PROGRAMA'],
+          study_area: row['ÁREA DEL CONOCIMIENTO'],
+          study_field: row['CAMPO'],
+          discipline: row['DISCIPLINA'],
+          sub_discipline: row['SUBDISCIPLINA'],
+          most_recent_gpa: row['PROMEDIO ÚLTIMO GRADO']
+        )
+      end
+      user.save
+    end
+    redirect_to success_redirect
+  end
+
+  def open_spreadsheet(file)
+    case File.extname(file.original_filename)
+    when ".csv" then  Roo::CSV.new(file.path, packed: nil, file_warning: :ignore, csv_options: {encoding: Encoding::SJIS})
+    when ".xls" then  Roo::Excel.new(file.path, packed: nil, file_warning: :ignore)
+    when ".xlsx" then  Roo::Excelx.new(file.path, packed: nil, file_warning: :ignore)
+    else raise "Unknown file type: #{file.original_filename}"
+    end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,4 +15,16 @@ class UserPolicy < ApplicationPolicy
   def new_with_former_student?
     @user.try :is_admin_or_super_admin?
   end
+
+  def former_students?
+    @user.try :is_admin_or_super_admin?
+  end
+
+  def former_students_upload?
+    @user.try :is_admin_or_super_admin?
+  end
+
+  def import_former_students?
+    @user.try :is_admin_or_super_admin?
+  end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
       <li id="dash_dashboard"><%= link_to 'Crear Convocatoria', new_scholarship_oportunity_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
       <li id="dash_dashboard"><%= link_to 'Vacantes', job_postings_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
       <li id="dash_dashboard"><%= link_to 'Compañias', companies_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
-      <li id="dash_dashboard"><%= link_to 'Registrar Exbecario', new_with_former_student_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
+      <li id="dash_dashboard"><%= link_to 'Exbecarios', former_students_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
       <% if current_user.super_admin? %>
         <li id="dash_dashboard"><%= link_to 'Registrar Administradores', new_user_registration_path, :style=>'color:#26a69a;', :class=>"waves-effect"%></li>
       <% end %>

--- a/app/views/students/_former_students_table.html.erb
+++ b/app/views/students/_former_students_table.html.erb
@@ -1,0 +1,33 @@
+<div id="man" class="col s12 m4 l10">
+    <div class="card material-table">
+    <div class="table-header">
+        <span class="table-title">Exbecarios</span>
+        <div class="actions">
+            <%= link_to 'Registrar', new_with_former_student_path, :class=>"btn-small"%>
+            <%= link_to 'Carga Masiva', former_students_upload_path, :class=>"btn-small"%>
+        </div>
+    </div>
+    <table id="datatable">
+        <thead>
+        <tr>
+            <th>Cvu</th>
+            <th>Nombre</th>
+            <th>  </th>
+        </tr>
+        </thead>
+        <tbody>
+        <% users.each do |user| %>
+            <tr>
+            <td><%= user.student.cvu %></td>
+            <td><%= user.student.full_name %></td>
+            <td><%= link_to 'Show', student_path(user.student.id), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
+                <% if user.student.curriculum %>
+                    <%= link_to 'Curriculum', curriculum_path(user.student.curriculum), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
+                <% end %>
+                <%= link_to "Eliminar", user.student, method: :delete, data: { confirm: '¿Estás seguro que quieres eliminar al usuario?' },:style=>'color:white;;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn" %></td>
+            </tr>
+        <% end %>
+        </tbody>
+    </table>
+    </div>
+</div>

--- a/app/views/students/former_students.html.erb
+++ b/app/views/students/former_students.html.erb
@@ -1,0 +1,10 @@
+<main style="padding-left: 240px">
+<div class="row">
+  <div class="col s12"><p></p></div>
+  <div class="col s12 m4 l1"><p></p></div>
+  <%= render "former_students_table", users: @users %>
+  <div class="col s12 m4 l1"><p></p></div>
+</div>
+
+
+</main>

--- a/app/views/students/former_students_upload.html.erb
+++ b/app/views/students/former_students_upload.html.erb
@@ -1,0 +1,21 @@
+<main style="padding-left: 240px">
+  <div class="container">
+    <div class="row">
+      <div class="col s12"><p></p></div>
+      <div class="col s12 m4 l1"><p></p></div>
+      <h2>Carga Masiva de exbecarios</h2>
+      <%= form_tag import_former_students_path, multipart: true do %>
+        <div class="row file-field input-field">
+          <div class="col s3 btn-small">
+            Excel Exbecarios
+            <%= file_field_tag :file,:style=>'padding-top:10px', class: 'form-control' %><br>
+          </div>
+          <input class="col s8 offset-s1 file-path validate" type="text" placeholder="Sube el excel con los exbecarios"/>
+        </div>
+        <%= submit_tag 'Enviar',:style=>'color:white;font-size:10px;width:110px ! important', class: 'btn btn-primary'%>
+      <% end %>
+
+      <div class="col s12 m4 l1"><p></p></div>
+    </div>
+  </div>
+</main>

--- a/app/views/students/former_students_upload.html.erb
+++ b/app/views/students/former_students_upload.html.erb
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col s12"><p></p></div>
       <div class="col s12 m4 l1"><p></p></div>
-      <h2>Carga Masiva de exbecarios</h2>
+      <h2>Carga Masiva de Exbecarios</h2>
       <%= form_tag import_former_students_path, multipart: true do %>
         <div class="row file-field input-field">
           <div class="col s3 btn-small">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do
   resources :students do
     get 'history', on: :member
   end
+  get 'former_students' => 'students#former_students', as: 'former_students'
+  get 'former_students_upload' => 'students#former_students_upload', as: 'former_students_upload'
+  post 'import_former_students' => 'students#import_former_students', as: 'import_former_students'
   resources :curriculums, except: [:index, :destroy]
   resources :pages
   resources :scholarships


### PR DESCRIPTION
Enable mass upload of former students reusing the same Excel structure we previously had to upload students. 
In this PR the basic views of former students are also created but a next PR will focus on the data displayed in the former_students_table.

![Screenshot from 2020-05-18 14-12-19](https://user-images.githubusercontent.com/15165722/82250726-9fa36200-9911-11ea-9ab6-b71e626a901d.png)
