### PR TITLE
Add employment data to the former student table

### DIFF
--- a/app/views/students/_former_students_table.html.erb
+++ b/app/views/students/_former_students_table.html.erb
@@ -1,34 +1,58 @@
 <div id="man" class="col s12 m4 l10">
-    <div class="card material-table">
+  <div class="card material-table">
     <div class="table-header">
-        <span class="table-title">Exbecarios</span>
-        <div class="actions">
-            <%= link_to 'Registrar', new_with_former_student_path, :class=>"btn-small"%>
-            <%= link_to 'Carga Masiva', former_students_upload_path, :class=>"btn-small"%>
-            <%= link_to 'Descargar', former_students_path(format: :csv), :class=>"btn-small"%>
-        </div>
+      <span class="table-title">Exbecarios</span>
+      <div class="actions">
+        <%= link_to 'Registrar', new_with_former_student_path, :class=>"btn-small"%>
+        <%= link_to 'Carga Masiva', former_students_upload_path, :class=>"btn-small"%>
+        <%= link_to 'Descargar', former_students_path(format: :csv), :class=>"btn-small"%>
+      </div>
     </div>
     <table id="datatable">
-        <thead>
+      <thead>
         <tr>
-            <th>Cvu</th>
-            <th>Nombre</th>
-            <th>  </th>
+          <th>Cvu</th>
+          <th>Nombre</th>
+          <th>Empresa Actual</th>
+          <th>Puesto Actual</th>
+          <th>  </th>
         </tr>
-        </thead>
-        <tbody>
+      </thead>
+      <tbody>
         <% users.each do |user| %>
-            <tr>
+          <tr>
             <td><%= user.student.cvu %></td>
             <td><%= user.student.full_name %></td>
-            <td><%= link_to 'Show', student_path(user.student.id), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
-                <% if user.student.curriculum %>
-                    <%= link_to 'Curriculum', curriculum_path(user.student.curriculum), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
+            <td>
+              <% if user.student.curriculum %>
+                <% if user.student.curriculum.current_job.any? %>
+                  <%= user.student.curriculum.current_job.first.company %>
+                <% else %>
+                  Sin trabajo
                 <% end %>
-                <%= link_to "Eliminar", user.student, method: :delete, data: { confirm: '¿Estás seguro que quieres eliminar al usuario?' },:style=>'color:white;;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn" %></td>
-            </tr>
+              <% else %>
+                Sin datos
+              <% end %>
+            </td>
+            <td>
+              <% if user.student.curriculum %>
+                <% if user.student.curriculum.current_job.any? %>
+                  <%= user.student.curriculum.current_job.first.title %>
+                <% else %>
+                  Sin trabajo
+                <% end %>
+              <% else %>
+                Sin datos
+              <% end %>
+            </td>
+            <td><%= link_to 'Show', student_path(user.student.id), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
+              <% if user.student.curriculum %>
+                <%= link_to 'Curriculum', curriculum_path(user.student.curriculum), :style=>'color:white;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn"%><br></br>
+              <% end %>
+              <%= link_to "Eliminar", user.student, method: :delete, data: { confirm: '¿Estás seguro que quieres eliminar al usuario?' },:style=>'color:white;;font-size:10px;width:100px ! important',:class=>"waves-effect waves-light btn" %></td>
+          </tr>
         <% end %>
-        </tbody>
+      </tbody>
     </table>
-    </div>
+  </div>
 </div>


### PR DESCRIPTION
Add the employer and current job position in the former students table. This are the most relevant aspects of a former student to see in there, everything else can be seen in the detail of a student or by downloading the excel.

![Screenshot from 2020-05-19 13-02-50](https://user-images.githubusercontent.com/15165722/82361973-3be06e00-99d1-11ea-92b3-8698a7ecef28.png)
