### PR TITLE
Former student initial flow

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,8 @@ class PagesController < ApplicationController
     else
       if current_user.is_admin_or_super_admin?
         redirect_to pages_path
+      elsif current_user.first_time_former_student?
+        redirect_to first_time_login_path
       else
         redirect_to student_path(current_user.student.id)
       end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -2,7 +2,7 @@ class StudentsController < ApplicationController
   include ApplicationHelper
 
   before_action :set_student, only: [:show, :edit, :update, :destroy, :history]
-  before_action :authorize_user, only: [:index, :destroy, :former_students, :former_students_upload, :import_former_students]
+  before_action :authorize_user, only: [:index, :destroy, :former_students, :former_students_upload, :import_former_students, :first_time_login]
   before_action :authorize_update, only: [:edit, :update]
 
   FIELD_TO_NAME = { 
@@ -47,6 +47,10 @@ class StudentsController < ApplicationController
     import_users(params[:file], 'former_student', former_students_upload_path, former_students_path)
   end
 
+  def first_time_login
+    @student = current_user.student
+  end
+
   def show
     @user = @student.user
     authorize @student
@@ -57,7 +61,12 @@ class StudentsController < ApplicationController
 
   def update
     @student.update!(student_params)
-    redirect_to student_path(@student)
+    if current_user.first_time_former_student?
+      current_user.increment! :sign_in_count
+      redirect_to new_curriculum_path
+    else
+      redirect_to student_path(@student)
+    end
   end
 
   def destroy
@@ -112,7 +121,7 @@ class StudentsController < ApplicationController
                        :gender,
                        :marital_status,
                        :country_birth,
-                       :state_birth] if current_user.is_admin_or_super_admin?
+                       :state_birth] if current_user.is_admin_or_super_admin? or current_user.first_time_former_student?
     params.require(:student).permit(params_allowed)
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  after_action :after_login, :only => :create
 
   # GET /resource/sign_in
   # def new
@@ -12,6 +13,10 @@ class Users::SessionsController < Devise::SessionsController
   def create
     super
     flash.delete(:notice)
+  end
+
+  def after_login
+    current_user.increment! :sign_in_count
   end
 
   # DELETE /resource/sign_out

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,10 @@ class User < ApplicationRecord
     self.company? or self.super_admin?
   end
 
+  def first_time_former_student?
+    self.former_student? and self.sign_in_count == 1
+  end
+
   def update_imported_user(file)
     spreadsheet = open_spreadsheet(file)
     header = spreadsheet.row(4)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -27,4 +27,8 @@ class UserPolicy < ApplicationPolicy
   def import_former_students?
     @user.try :is_admin_or_super_admin?
   end
+
+  def first_time_login?
+    @user.try :first_time_former_student?
+  end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -53,7 +53,7 @@
         </li>
       <% end %>
       
-      <% elsif current_user.is_student_or_former_student? %>
+      <% elsif current_user.is_student_or_former_student? and !current_user.first_time_former_student? %>
       <li id="dash_dashboard">
         <%= link_to student_path(current_user.student), :class=>"waves-effect" do %>
           <i class="material-icons left">account_circle</i>Perfil

--- a/app/views/students/first_time_login.html.erb
+++ b/app/views/students/first_time_login.html.erb
@@ -1,0 +1,47 @@
+<main style="padding-left: 240px">
+  <div class="container">
+    <div class="row">
+      <div class="col s12" style="padding-top: 20px;">
+        <h4 class="center-align">¡Bienvenido <%= @student.full_name %>!</h4>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col s12">
+        <p class="flow-text">
+          Primero que nada nos gustaría que confirmes los datos que el I2T2 tiene de cuando realizaste tus estudios con la beca Conacyt.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col s12">
+        <h3>Datos Personales</h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col s12">
+        <p class="flow-text zeroMargin">Una vez confirmados estos datos no los podrás actualizar más tarde.</p>
+      </div>
+    </div>
+    <%= form_for @student do |f| %>
+      <%= render "form", f: f %>
+      <div class="row">
+        <div class="col s12">
+          <h3>Datos de Contacto</h3>
+        </div>
+      </div>
+      <%= f.fields_for :contact_information do |c| %>
+          <%= render "form_contact_information", c: c %>
+      <% end %>
+      <div class="row">
+        <div class="col s12">
+          <blockquote class="flow-text">
+            Al hacer click en confirmar verifico que mis datos son correctos y completos.
+          </blockquote>
+        </div>
+      </div>
+      <div class="actions center-align">
+          <%= f.submit "Confirmar", :class=>"btn"%>
+      </div>
+    <% end %>
+  </div>
+</main>

--- a/app/views/students/first_time_login.html.erb
+++ b/app/views/students/first_time_login.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row">
       <div class="col s12" style="padding-top: 20px;">
-        <h4 class="center-align">¡Bienvenido <%= @student.full_name %>!</h4>
+        <h4 class="center-align">¡Bienvenido/a <%= @student.full_name %>!</h4>
       </div>
     </div>
     <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   get 'former_students' => 'students#former_students', as: 'former_students'
   get 'former_students_upload' => 'students#former_students_upload', as: 'former_students_upload'
   post 'import_former_students' => 'students#import_former_students', as: 'import_former_students'
+  get 'first_time_login' => 'students#first_time_login', as: 'first_time_login'
   resources :curriculums, except: [:index, :destroy]
   resources :pages
   resources :scholarships

--- a/db/migrate/20190927055513_devise_create_users.rb
+++ b/db/migrate/20190927055513_devise_create_users.rb
@@ -15,7 +15,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.datetime :remember_created_at
 
       ## Trackable
-      # t.integer  :sign_in_count, default: 0, null: false
+      t.integer  :sign_in_count, default: 0, null: false
       # t.datetime :current_sign_in_at
       # t.datetime :last_sign_in_at
       # t.inet     :current_sign_in_ip

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_223008) do
     t.string "employment_type"
     t.text "responsabilities"
     t.string "experience_required"
+    t.date "expiration"
     t.integer "company_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -192,6 +193,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_223008) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "role"


### PR DESCRIPTION
Implement the initial flow for a former student when he signs in for the first time on the website. The user is allowed to update his personal information and contact information only this time.

In a next PR, I will add the unemployment form so that the former student can write about whether or not he is employed and the reason of unemployment if such former student is not employed.

![Screenshot from 2020-05-20 16-55-04](https://user-images.githubusercontent.com/15165722/82501631-2ba4bd80-9abb-11ea-9624-f1d31140da9c.png)

![Screenshot from 2020-05-20 16-55-07](https://user-images.githubusercontent.com/15165722/82501646-30697180-9abb-11ea-8667-422c7e372086.png)
