### PR TITLE
Add regex patterns for validations

### DIFF
--- a/app/views/students/_form.html.erb
+++ b/app/views/students/_form.html.erb
@@ -1,14 +1,14 @@
 <div class="col s12 m6 l4 input-field">
   <%= f.label :name, 'Nombre*'%>
-  <%= f.text_field :name, :required => true%>
+  <%= f.text_field :name, :required => true, :pattern => '[A-Za-zÀ-ÖØ-öø-ÿ]*' %>
 </div>
 <div class="col s12 m6 l4 input-field">
   <%= f.label :paternal_last_name, 'Apellido paterno' %>
-  <%= f.text_field :paternal_last_name %>
+  <%= f.text_field :paternal_last_name, :pattern => '[A-Za-zÀ-ÖØ-öø-ÿ]*' %>
 </div>
 <div class="col s12 m6 l4 input-field">
   <%= f.label :maternal_last_name, 'Apellido materno' %>
-  <%= f.text_field :maternal_last_name %>
+  <%= f.text_field :maternal_last_name, :pattern => '[A-Za-zÀ-ÖØ-öø-ÿ]*' %>
 </div>
 <div class="col s12 m6 l4 input-field">
   <%= f.label :cvu, 'CVU*'%>

--- a/app/views/students/_form_contact_information.html.erb
+++ b/app/views/students/_form_contact_information.html.erb
@@ -6,11 +6,11 @@
   <div class="row zeroMargin">
     <div class="col s4 input-field inline">
         <%= c.label :phone_number, 'Teléfono' %>
-        <%= c.telephone_field :phone_number %>
+        <%= c.telephone_field :phone_number, :pattern => "\\d*" %>
     </div>
     <div class="col s4 input-field inline">
         <%= c.label :cellphone_number, 'Celular' %>
-        <%= c.telephone_field :cellphone_number %>
+        <%= c.telephone_field :cellphone_number, :pattern => "\\d*" %>
     </div>
   </div>
 </div>

--- a/app/views/students/_form_contact_information.html.erb
+++ b/app/views/students/_form_contact_information.html.erb
@@ -6,11 +6,11 @@
   <div class="row zeroMargin">
     <div class="col s4 input-field inline">
         <%= c.label :phone_number, 'Teléfono' %>
-        <%= c.telephone_field :phone_number, :pattern => "\\d*" %>
+        <%= c.telephone_field :phone_number, :pattern => "[0-9]*" %>
     </div>
     <div class="col s4 input-field inline">
         <%= c.label :cellphone_number, 'Celular' %>
-        <%= c.telephone_field :cellphone_number, :pattern => "\\d*" %>
+        <%= c.telephone_field :cellphone_number, :pattern => "[0-9]*" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Add regex patterns to validate phone numbers are only digits (0-9) and names contain only valid characters (no numbers, symbols, etc). The regex used for names was retrieved from: https://stackoverflow.com/questions/20690499/concrete-javascript-regex-for-accented-characters-diacritics